### PR TITLE
Fix: Support multiple compose files in swarm mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,6 +130,48 @@ jobs:
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
 
+      - name: "5: Write Base YAML"
+        if: ${{ !cancelled() }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.base.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+
+      - name: "5: Write Override YAML"
+        if: ${{ !cancelled() }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.override.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"environment":{"TEST":"multiple-files"}}}}
+
+      - name: "5: Test Multiple Files (Swarm)"
+        if: ${{ !cancelled() }}
+        uses: ./
+        with:
+          name: test_stack-deploy-multi
+          file: docker-compose.base.yaml docker-compose.override.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          detach: false
+          resolve_image: "changed"
+
+      - name: "6: Test Multiple Files (Compose)"
+        if: ${{ !cancelled() }}
+        uses: ./
+        with:
+          name: test_stack-deploy-compose-multi
+          file: docker-compose.base.yaml docker-compose.override.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          mode: compose
+          summary: false
+
       - name: "Schedule Failure Notification"
         if: ${{ failure() && github.event_name == 'schedule' }}
         uses: sarisia/actions-status-discord@v1

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can also view an [Action Comparison](https://docker-deploy.cssnr.com/guides/
 | Input&nbsp;Name      | Default&nbsp;Value                  | Short&nbsp;Description&nbsp;of&nbsp;the&nbsp;Input&nbsp;Value      |
 | :------------------- | :---------------------------------- | :----------------------------------------------------------------- |
 | `name`               | _Required_                          | Docker Stack/Project Name [⤵️](#name)                              |
-| `file`               | `docker-compose.yaml`               | Docker Stack/Compose File(s) (supports multiple) [⤵️](#file)                           |
+| `file`               | `docker-compose.yaml`               | Docker Stack/Compose File(s) (supports multiple) [⤵️](#file)       |
 | `mode`**¹**          | `swarm`                             | Deploy Mode [`swarm`, `compose`] [⤵️](#mode)                       |
 | `args`**¹**          | `--remove-orphans --force-recreate` | Additional **Compose** Arguments [⤵️](#args)                       |
 | `host`               | _Required_                          | Remote Docker Hostname or IP [⤵️](#host)                           |
@@ -137,6 +137,7 @@ fi
 ```
 
 **Note:** `"${STACK_FILES[@]}"` is an array of file paths with the appropriate flag prepended:
+
 - **Swarm mode:** `-c file1.yaml -c file2.yaml` for each file
 - **Compose mode:** `-f file1.yaml -f file2.yaml` for each file
 
@@ -158,6 +159,7 @@ Stack name for Swarm and project name for Compose.
 Stack file or Compose file(s). Multiple files can be provided, space-separated, and a `-c` flag (for swarm) or `-f` flag (for compose) will be prepended to each file.
 
 **Examples:**
+
 - Single file: `docker-compose.yaml`
 - Multiple files: `base.yaml production.yaml`
 
@@ -389,13 +391,13 @@ Additional [Examples](https://docker-deploy.cssnr.com/guides/examples) are avail
     args: --remove-orphans --force-recreate
 ```
 
-
 Note: these are the default arguments. If you use `args` this will override the default arguments unless they are included.
 You can disable them by passing an empty string. For more details, see the compose up [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
 <details><summary>Multiple Compose Files (Swarm Mode)</summary>
 
 Deploy with a base configuration and environment-specific overrides:
+
 ```yaml
 - name: 'Stack Deploy'
   uses: cssnr/stack-deploy-action@v1

--- a/src/main.sh
+++ b/src/main.sh
@@ -164,21 +164,26 @@ fi
 echo "::debug::EXTRA_ARGS: ${EXTRA_ARGS[*]}"
 
 ## Collect Stack Files
-
+STACK_FILES=()
 if [[ "${INPUT_MODE}" == "compose" ]];then
-    STACK_FILES=()
     read -r -a files <<< "${INPUT_FILE}"
     for file in "${files[@]}";do
         STACK_FILES+=("-f" "$file")
     done
-    echo "::debug::STACK_FILES: ${STACK_FILES[*]}"
+    echo "::debug::COMPOSE STACK_FILES: ${STACK_FILES[*]}"
+elif [[ "${INPUT_MODE}" == "swarm" ]];then
+    read -r -a files <<< "${INPUTE_FILE}"
+    for file in "${files[@]}";do
+        STACK_FILES+=("-c" "$file")
+    done
+    echo "::debug::SWARM STACK_FILES: ${STACK_FILES[*]}"
 fi
 
 ## Deploy Stack
 
 if [[ "${INPUT_MODE}" == "swarm" ]];then
     DEPLOY_TYPE="Swarm"
-    COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
+    COMMAND=("docker" "stack" "deploy" "${STACK_FILES[@]}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 else
     DEPLOY_TYPE="Compose"
     COMMAND=("docker" "compose" "${STACK_FILES[@]}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")

--- a/src/main.sh
+++ b/src/main.sh
@@ -165,6 +165,7 @@ echo "::debug::EXTRA_ARGS: ${EXTRA_ARGS[*]}"
 
 ## Collect Stack Files
 STACK_FILES=()
+
 if [[ "${INPUT_MODE}" == "compose" ]];then
     read -r -a files <<< "${INPUT_FILE}"
     for file in "${files[@]}";do
@@ -172,7 +173,7 @@ if [[ "${INPUT_MODE}" == "compose" ]];then
     done
     echo "::debug::COMPOSE STACK_FILES: ${STACK_FILES[*]}"
 elif [[ "${INPUT_MODE}" == "swarm" ]];then
-    read -r -a files <<< "${INPUTE_FILE}"
+    read -r -a files <<< "${INPUT_FILE}"
     for file in "${files[@]}";do
         STACK_FILES+=("-c" "$file")
     done


### PR DESCRIPTION
- Added file splitting logic for swarm mode (similar to compose mode)
- Each file now gets its own -c flag in swarm deployments
- Fixes issue where multiple files were treated as a single filename

Before: docker stack deploy -c \"file1 file2\" stack-name
After:  docker stack deploy -c file1 -c file2 stack-name

# Overview



## Checklist
<!-- Do NOT remove tasks and append any custom tasks -->
- [x] Verify the Required Checks are Passing
- [x] Document changes in the [README.md](../blob/master/README.md) (for new features)